### PR TITLE
Settings file security

### DIFF
--- a/local_settings/settings.py
+++ b/local_settings/settings.py
@@ -57,11 +57,11 @@ MIDDLEWARE = [
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'housing-2019-staging',
-        'USER': 'housing2019',
-        'PASSWORD': '9wpXkWvNujAV',
-        'HOST': 'housing-2019-staging.caicgny9d8nv.us-west-2.rds.amazonaws.com',
-        'PORT': '5432',
+        "PASSWORD": os.environ.get("POSTGRES_PASSWORD"),
+        "NAME": os.environ.get("POSTGRES_NAME"),
+        "USER": os.environ.get("POSTGRES_USER"),
+        "HOST": os.environ.get("POSTGRES_HOST"),
+        "PORT": os.environ.get("POSTGRES_PORT"),
     },
 }
 


### PR DESCRIPTION
Instead of hardcoding the secrets, this will pull them from the `.env` file which is not under source control. I'm going to merge this in right away due to the security risk.